### PR TITLE
Implement angle wrapping and introduce time delay functionality

### DIFF
--- a/fuse_constraints/include/fuse_constraints/normal_prior_pose_3d_euler_cost_functor.hpp
+++ b/fuse_constraints/include/fuse_constraints/normal_prior_pose_3d_euler_cost_functor.hpp
@@ -115,10 +115,11 @@ bool NormalPriorPose3DEulerCostFunctor::operator()(
   full_residuals[0] = position[0] - T(b_(0));
   full_residuals[1] = position[1] - T(b_(1));
   full_residuals[2] = position[2] - T(b_(2));
-  // Compute the orientation residual
-  full_residuals[3] = orientation_rpy[0] - T(b_(3));
-  full_residuals[4] = orientation_rpy[1] - T(b_(4));
-  full_residuals[5] = orientation_rpy[2] - T(b_(5));
+  // Compute the orientation residual. Wrap into (-Pi, Pi] so a heading straddling the +-Pi branch
+  // cut yields a ~0 error instead of a spurious ~2*Pi one. Matches NormalPriorPose3DEuler::Evaluate.
+  full_residuals[3] = fuse_core::wrapAngle2D(orientation_rpy[0] - T(b_(3)));
+  full_residuals[4] = fuse_core::wrapAngle2D(orientation_rpy[1] - T(b_(4)));
+  full_residuals[5] = fuse_core::wrapAngle2D(orientation_rpy[2] - T(b_(5)));
 
   // Scale the residuals by the square root information matrix to account for
   // the measurement uncertainty.

--- a/fuse_constraints/src/normal_prior_pose_3d_euler.cpp
+++ b/fuse_constraints/src/normal_prior_pose_3d_euler.cpp
@@ -69,10 +69,13 @@ bool NormalPriorPose3DEuler::Evaluate(
   full_residuals(1) = parameters[0][1] - b_(1);
   full_residuals(2) = parameters[0][2] - b_(2);
 
-  // Compute the orientation residual
-  full_residuals(3) = orientation_rpy[0] - b_(3);
-  full_residuals(4) = orientation_rpy[1] - b_(4);
-  full_residuals(5) = orientation_rpy[2] - b_(5);
+  // Compute the orientation residual. Wrap into (-Pi, Pi] so a heading straddling the +-Pi branch
+  // cut yields a ~0 error instead of a spurious ~2*Pi one (which otherwise yanks yaw to the wrong
+  // branch). Matches the motion-model cost function; the analytic Jacobian is unchanged because
+  // wrapping shifts the residual by a constant multiple of 2*Pi.
+  full_residuals(3) = fuse_core::wrapAngle2D(orientation_rpy[0] - b_(3));
+  full_residuals(4) = fuse_core::wrapAngle2D(orientation_rpy[1] - b_(4));
+  full_residuals(5) = fuse_core::wrapAngle2D(orientation_rpy[2] - b_(5));
 
   // Scale the residuals by the square root information matrix to account for
   // the measurement uncertainty.

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.hpp
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.hpp
@@ -184,7 +184,11 @@ protected:
   // Guarded by optimization_mutex_
   std::mutex optimization_mutex_;  //!< Mutex held while the graph is begin optimized
   // fuse_core::Graph* graph_ member from the base class
-  rclcpp::Time lag_expiration_;  //!< The oldest stamp that is inside the fixed-lag smoother window
+  // Must be initialized as ROS time: in the auto-start path (no ignition sensor) the first
+  // transaction reaches the lag-expiration comparison in processQueue() before the first
+  // optimization cycle assigns this, and a default-constructed (system-time) value makes that
+  // comparison throw "can't compare times with different time sources", killing the node.
+  rclcpp::Time lag_expiration_ {0, 0, RCL_ROS_TIME};  //!< The oldest stamp inside the lag window
   fuse_core::Transaction marginal_transaction_;  //!< The marginals to add during the next
                                                  //!< optimization cycle
   VariableStampIndex timestamp_tracking_;  //!< Object that tracks the timestamp associated with


### PR DESCRIPTION
This pull request introduces important fixes and improvements to angle handling in 3D pose residual calculations and addresses a potential initialization issue in the fixed-lag smoother. The main changes ensure that orientation residuals are properly wrapped to avoid discontinuities at the ±π boundary, and that time initialization is robust to prevent runtime errors.

**Pose residual computation improvements:**

* Orientation residuals in both `NormalPriorPose3DEulerCostFunctor::operator()` (`normal_prior_pose_3d_euler_cost_functor.hpp`) and `NormalPriorPose3DEuler::Evaluate()` (`normal_prior_pose_3d_euler.cpp`) now use `fuse_core::wrapAngle2D` to wrap angle differences into the (-π, π] interval. This prevents large, incorrect errors when angles cross the ±π boundary and ensures consistent behavior with the motion-model cost function. [[1]](diffhunk://#diff-3c3b9924bcebf46b6493694e203b470b29cf2cd7357309b72d536075d05ac176L118-R122) [[2]](diffhunk://#diff-13b774af7e281acbfdbef546c97b65f7324007fb441f04c59863c337c8ddad27L72-R78)

**Fixed-lag smoother robustness:**

* The `lag_expiration_` member in `FixedLagSmoother` (`fixed_lag_smoother.hpp`) is now explicitly initialized as a ROS time value. This prevents exceptions caused by comparing uninitialized or mismatched time sources, especially in auto-start scenarios without an ignition sensor.