### PR TITLE
Pitch compensation / ZUPT / GNSS Acquisition

### DIFF
--- a/fuse_models/include/fuse_models/odometry_3d.hpp
+++ b/fuse_models/include/fuse_models/odometry_3d.hpp
@@ -171,6 +171,17 @@ protected:
 
   geometry_msgs::msg::PoseWithCovarianceStamped::UniquePtr previous_pose_;
 
+  // Reacquisition covariance ramp: after this source drops out and returns, its
+  // absolute pose would snap the estimate off the dead-reckoned trajectory in one
+  // step. The position covariance of the first messages after the gap is inflated
+  // (scaled by outage length) and decayed over reacquisition_tau_s so the estimate
+  // slides back instead of snapping. Off unless reacquisition_tau_s > 0.
+  rclcpp::Time last_message_stamp_ {0, 0, RCL_ROS_TIME};
+  rclcpp::Time reacquisition_ramp_start_ {0, 0, RCL_ROS_TIME};
+  double reacquisition_initial_variance_ {0.0};
+  double reacquisition_initial_orient_variance_ {0.0};
+  bool in_reacquisition_ramp_ {false};
+
   // NOTE(CH3): Unique ptr to defer till we have the node interfaces from initialize()
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::unique_ptr<tf2_ros::TransformListener> tf_listener_;

--- a/fuse_models/include/fuse_models/parameters/odometry_3d_params.hpp
+++ b/fuse_models/include/fuse_models/parameters/odometry_3d_params.hpp
@@ -166,6 +166,16 @@ public:
         fuse_core::joinParameterName(ns, "twist_covariance_offset_diagonal"), 0.0);
     }
 
+    reacquisition_tau_s = fuse_core::getParam(
+      interfaces, fuse_core::joinParameterName(ns, "reacquisition_tau_s"),
+      reacquisition_tau_s);
+    reacquisition_position_softening_mps = fuse_core::getParam(
+      interfaces, fuse_core::joinParameterName(ns, "reacquisition_position_softening_mps"),
+      reacquisition_position_softening_mps);
+    reacquisition_heading_softening_radps = fuse_core::getParam(
+      interfaces, fuse_core::joinParameterName(ns, "reacquisition_heading_softening_radps"),
+      reacquisition_heading_softening_radps);
+
     pose_loss =
       fuse_core::loadLossConfig(interfaces, fuse_core::joinParameterName(ns, "pose_loss"));
     linear_velocity_loss =
@@ -184,6 +194,18 @@ public:
   bool disable_checks {false};
   bool independent {true};
   bool use_twist_covariance {true};
+  //!< Smooth reacquisition after an outage: on the first messages back, the pose covariance is
+  //!< inflated (so the stiff dead-reckoned estimate is not yanked to the fix in one solve) and
+  //!< decayed over reacquisition_tau_s, so the estimate slides back over a few seconds. See
+  //!< DEAD_RECKONING.md section 8. Off unless reacquisition_tau_s > 0.
+  double reacquisition_tau_s {0.0};  //!< Covariance-decay time constant (s); reconverge ~2-3x this. <=0 = off.
+  //!< Initial position-std added per second of outage (m). Deliberately set ABOVE physical drift
+  //!< to exceed the estimator's (overconfident) dead-reckoning covariance - otherwise the smoother
+  //!< still takes a first-solve "bite". Higher = smaller initial step, slower reconvergence.
+  double reacquisition_position_softening_mps {0.0};
+  //!< Initial heading-std added per second of outage (rad); softens the yaw correction so the
+  //!< heading eases back instead of jerking (which would rotate the whole velocity vector).
+  double reacquisition_heading_softening_radps {0.0};
   fuse_core::Matrix6d minimum_pose_relative_covariance;  //!< Minimum pose relative covariance
                                                          //!< matrix
   fuse_core::Matrix6d twist_covariance_offset;    //!< Offset already added to the twist covariance

--- a/fuse_models/src/odometry_3d.cpp
+++ b/fuse_models/src/odometry_3d.cpp
@@ -31,6 +31,8 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <algorithm>
+#include <cmath>
 #include <memory>
 #include <utility>
 
@@ -49,6 +51,13 @@ PLUGINLIB_EXPORT_CLASS(fuse_models::Odometry3D, fuse_core::SensorModel)
 
 namespace fuse_models
 {
+
+namespace
+{
+constexpr double kReacquisitionGapThresholdSec = 0.3;  // publish gap that counts as an outage
+constexpr double kReacquisitionMaxStdM = 100.0;        // safety clamp on the initial ramp position std
+constexpr double kReacquisitionMaxOrientStdRad = 0.5;  // safety clamp on the initial ramp yaw std
+}  // namespace
 
 Odometry3D::Odometry3D()
 : fuse_core::AsyncSensorModel(1),
@@ -147,6 +156,48 @@ void Odometry3D::process(const nav_msgs::msg::Odometry & msg)
   twist.header = msg.header;
   twist.header.frame_id = msg.child_frame_id;
   twist.twist = msg.twist;
+
+  // Reacquisition covariance ramp (absolute pose only): after this source drops out
+  // and returns, soften its position AND orientation covariance - scaled by the outage
+  // length and decayed over reacquisition_tau_s - so the estimate slides back to the
+  // fix instead of snapping off the dead-reckoned trajectory in one optimizer step.
+  // Orientation is ramped too: during the outage the heading dead-reckons (gyro drift),
+  // and a hard yaw correction rotates the whole velocity vector - the harshest part of
+  // the snap even when position is already softened.
+  if (!params_.differential && params_.reacquisition_tau_s > 0.0) {
+    const rclcpp::Time stamp(msg.header.stamp);
+    if (last_message_stamp_.nanoseconds() > 0) {
+      const double gap = (stamp - last_message_stamp_).seconds();
+      if (gap > kReacquisitionGapThresholdSec) {
+        const double pos_std = std::min(
+          gap * params_.reacquisition_position_softening_mps, kReacquisitionMaxStdM);
+        const double yaw_std = std::min(
+          gap * params_.reacquisition_heading_softening_radps, kReacquisitionMaxOrientStdRad);
+        reacquisition_initial_variance_ = pos_std * pos_std;
+        reacquisition_initial_orient_variance_ = yaw_std * yaw_std;
+        reacquisition_ramp_start_ = stamp;
+        in_reacquisition_ramp_ =
+          reacquisition_initial_variance_ > 0.0 || reacquisition_initial_orient_variance_ > 0.0;
+      }
+    }
+    last_message_stamp_ = stamp;
+    if (in_reacquisition_ramp_) {
+      const double dt = (stamp - reacquisition_ramp_start_).seconds();
+      const double decay = std::exp(-2.0 * dt / params_.reacquisition_tau_s);
+      const double pos_inflation = reacquisition_initial_variance_ * decay;
+      const double orient_inflation = reacquisition_initial_orient_variance_ * decay;
+      if (pos_inflation < 1e-4 && orient_inflation < 1e-6) {
+        in_reacquisition_ramp_ = false;
+      } else {
+        pose->pose.covariance[0] += pos_inflation;
+        pose->pose.covariance[7] += pos_inflation;
+        pose->pose.covariance[14] += pos_inflation;
+        pose->pose.covariance[21] += orient_inflation;
+        pose->pose.covariance[28] += orient_inflation;
+        pose->pose.covariance[35] += orient_inflation;
+      }
+    }
+  }
 
   const bool validate = !params_.disable_checks;
 


### PR DESCRIPTION
This pull request adds a "reacquisition covariance ramp" feature to the `Odometry3D` sensor model, improving how the estimator handles pose source outages and recoveries. When the odometry source drops out and resumes, the pose covariance is temporarily inflated and decayed over time, allowing the estimate to "slide" back to the correct pose rather than snapping abruptly. This behavior is configurable via new parameters.

**Reacquisition Covariance Ramp Feature:**

* Added member variables to `Odometry3D` to track the state and timing of the reacquisition ramp, including timers, variances, and flags.
* Implemented logic in `Odometry3D::process()` to detect outages, compute and apply covariance inflation based on outage duration, and decay the inflation over a configurable time constant.
* Introduced internal constants for outage detection threshold and safety clamps on maximum covariance inflation.

**Configuration and Parameters:**

* Added new parameters to `Odometry3DParams` for configuring the ramp behavior: `reacquisition_tau_s`, `reacquisition_position_softening_mps`, and `reacquisition_heading_softening_radps`, including documentation and parameter loading. [[1]](diffhunk://#diff-87f251ab3701eeb72565a2d9f6b09d7d76c56fddf04c592ade8aed48a9ba0011R169-R178) [[2]](diffhunk://#diff-87f251ab3701eeb72565a2d9f6b09d7d76c56fddf04c592ade8aed48a9ba0011R197-R208)

**Code Quality:**

* Included `<algorithm>` and `<cmath>` headers for mathematical operations used in the new logic.